### PR TITLE
snapshot.md updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,6 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # gem "rails"
 
-gem "jekyll", "~> 4.0"
+gem "jekyll", "~> 4.1.1"
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.7)
-    em-websocket (0.5.2)
+    concurrent-ruby (1.1.9)
+    em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
-      http_parser.rb (~> 0.6.0)
+      http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.13.1)
+    ffi (1.15.5)
     forwardable-extended (2.6.0)
-    http_parser.rb (0.6.0)
-    i18n (1.8.5)
+    http_parser.rb (0.8.0)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jekyll (4.1.1)
       addressable (~> 2.4)
@@ -33,35 +33,37 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.2.1)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
-    rb-fsevent (0.10.4)
+    rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
-    rouge (3.23.0)
+    rexml (3.2.5)
+    rouge (3.28.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.7.0)
+    unicode-display_width (1.8.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  jekyll (~> 4.0)
+  jekyll (~> 4.1.1)
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.1.4
+   2.3.4

--- a/_config.yml
+++ b/_config.yml
@@ -1,47 +1,55 @@
+title: Tezos Snapshots
+author: Oxhead Alpha
+description: > # this means to ignore newlines until "show_excerpts:"
+  Tezos Snapshots
+favicon: "./favicon.ico" # set the favicon of the site
+show_excerpts: false # set to true to show excerpts on the homepage
+# url becomes localhost in development environments
+url: https://xtz-shots.io
+domain_name: xtz-shots.io
+
 # Theme settings
 doks:
-    baseurl:
-    color_theme: blue # Available themes: blue (default), green, purple, red and yellow
-    header:
-        logo:
-            text: XTZ-Shots
-            image:
-            logo_url: 'https://xtz-shots.io'
-        nav:
-            - item_name: Mainnet
-              item_url: 'https://mainnet.xtz-shots.io/'
-            - item_name: Ithacanet
-              item_url: 'https://ithacanet.xtz-shots.io/'
-            - item_name: Hangzhounet
-              item_url: 'https://hangzhounet.xtz-shots.io/'
+  baseurl:
+  color_theme: blue # Available themes: blue (default), green, purple, red and yellow
+  header:
+    logo:
+      text: XTZ-Shots
+      image:
+      logo_url: "https://xtz-shots.io"
+    nav:
+      - item_name: Mainnet
+        item_url: "https://mainnet.xtz-shots.io/"
+      - item_name: Ithacanet
+        item_url: "https://ithacanet.xtz-shots.io/"
+      - item_name: Hangzhounet
+        item_url: "https://hangzhounet.xtz-shots.io/"
 
-    footer:
-        content:
-            logo:
-                text: XTZ-Shots
-                image:
-            copyright: Copyright &copy; 2021. - Oxhead Alpha <br>All rights reserved.
-        social_list:
-            - network_name: github
-              profile_url: 'https://github.com/oxheadalpha'
-            - network_name: twitter
-              profile_url: 'https://twitter.com/oxheadalpha'
-            - network_name: sphere
-              profile_url: 'https://oxheadalpha.com'
-    google_analytics:
-        tracking_code: # Add your Google Analytics tracking code to activate Google Analytics
-    comments:
-        disqus_forum_shortname: # Add your disqus forum shortname to activate comments
+  footer:
+    content:
+      logo:
+        text: XTZ-Shots
+        image:
+      copyright: Copyright &copy; 2021. - Oxhead Alpha <br>All rights reserved.
+    social_list:
+      - network_name: github
+        profile_url: "https://github.com/oxheadalpha"
+      - network_name: twitter
+        profile_url: "https://twitter.com/oxheadalpha"
+      - network_name: sphere
+        profile_url: "https://oxheadalpha.com"
+  google_analytics:
+    tracking_code: # Add your Google Analytics tracking code to activate Google Analytics
+  comments:
+    disqus_forum_shortname: # Add your disqus forum shortname to activate comments
 
 # SASS settings
 sass:
-    sass_dir: ./_sass
-    style: :compressed
+  sass_dir: ./_sass
+  style: :compressed
 
 # Jekyll settings
 layouts_dir: ./_layouts
 includes_dir: ./_includes
-exclude: [ 'README.md', 'CHANGELOG.md' ]
+exclude: ["README.md", "CHANGELOG.md"]
 permalink: /:title/
-
-favicon: '/favicon.ico'

--- a/_data/archive_tarball.json
+++ b/_data/archive_tarball.json
@@ -1,0 +1,13 @@
+{
+  "block_hash": "BLF2afPXoGGvSEf6VX1tm4Gr1DZstF57ZpGS19qjUn9amdysq28",
+  "block_height": "2140965",
+  "block_timestamp": "2022-02-22T23:49:00Z",
+  "filename": "mainnet-2140965.BLAH.BLAH.rolling",
+  "filesize_bytes": "3365351291",
+  "filesize": "3G",
+  "sha256": "99320f17fd35c0bcb7ecaa05f8b26d0fadf459041c21110319c915897e4ae8f0",
+  "tezos_version": "0e7a0e9a (2021-11-15 11:05:56 +0100) (11.0)",
+  "chain_name": "mainnet",
+  "history_mode": "archive",
+  "artifact_type": "tezos-snapshot"
+}

--- a/_data/rolling_snapshot.json
+++ b/_data/rolling_snapshot.json
@@ -1,0 +1,13 @@
+{
+  "block_hash": "BKtbLxjFFuJRdEC3uzvZVuxx2RvgeeHAke3NMueQUGfrMSooaaK",
+  "block_height": "2148668",
+  "block_timestamp": "2022-02-25T17:48:24Z",
+  "rolling_snapshot_filename": "mainnet-2148668.rolling",
+  "filesize_bytes": "$FILESIZE_BYTES",
+  "filesize": "3G",
+  "sha256": "b17d7b0d7ca30a877fb3d5646e63d1141f55596c7bca35ef92d77a9a32a4582b",
+  "tezos_version": "0e7a0e9a (2021-11-15 11:05:56 +0100) (11.0)",
+  "chain_name": "mainnet",
+  "history_mode": "rolling",
+  "artifact_type": "tezos-snapshot"
+}

--- a/_data/rolling_tarball.json
+++ b/_data/rolling_tarball.json
@@ -1,0 +1,13 @@
+{
+  "block_hash": "BLe2Jffs2igeKZzc3V8vvUdcZfdaXGncnjVpJXyVxm9aFfKCvgh",
+  "block_height": "2148274",
+  "block_timestamp": "2022-02-25T14:29:04Z",
+  "rolling_tarball_filename": "tezos-mainnet-rolling-tarball-2148274.lz4",
+  "sha256": "7cdcd254be0f077e282f86d393cba73bde853d6bb3e5540c823c84b847572e39",
+  "filesize_bytes": "3365351291",
+  "filesize": "3G",
+  "tezos_version": "0e7a0e9a (2021-11-15 11:05:56 +0100) (11.0)",
+  "chain_name": "mainnet",
+  "history_mode": "rolling",
+  "artifact_type": "tarball"
+}

--- a/_data/tezos_metadata.json
+++ b/_data/tezos_metadata.json
@@ -1,0 +1,3 @@
+{
+  "network": "mainnet"
+}

--- a/snapshot.md
+++ b/snapshot.md
@@ -46,7 +46,7 @@ Octez version used for snapshotting: `{{ site.data.rolling_snapshot.tezos_versio
 
 ## Rolling snapshot
 
-[Download Rolling Snapshot]({{ domain_name }}/{{ site.data.rolling_snapshot.filename }}?{{ randomNumber }})
+[Download Rolling Snapshot]({{ domain_name }}/{{ site.data.rolling_snapshot.filename }})
 
 Block height: `{{ site.data.rolling_snapshot.block_height }}`
 
@@ -68,7 +68,7 @@ Checksum (SHA256):
 
 ## Archive tarball
 
-[Download Archive Tarball]({{ domain_name }}/{{ site.data.archive_tarball.filename }}?{{ randomNumber }})
+[Download Archive Tarball]({{ domain_name }}/{{ site.data.archive_tarball.filename }})
 
 Block height: `{{ site.data.archive_tarball.block_height }}`
 
@@ -90,7 +90,7 @@ Checksum (SHA256):
 
 ## Rolling tarball
 
-[Download Rolling Tarball]({{ domain_name }}/{{ site.data.rolling_tarball.filename }}?{{ randomNumber }})
+[Download Rolling Tarball]({{ domain_name }}/{{ site.data.rolling_tarball.filename }})
 
 Block height: `{{ site.data.rolling_tarball.block_height }}`
 

--- a/snapshot.md
+++ b/snapshot.md
@@ -22,7 +22,7 @@ page_nav:
 ---
 
 {% assign network_substring = site.data.tezos_metadata.network | remove: "net" %}
-{% capture domain_name %}https://{{ site.data.tezos_metadata.network }}.{{ site.domain_name }}{% endcapture %}
+{% capture domain_name %}https://{{ site.data.tezos_metadata.network }}.xtz-shots.io{% endcapture %}
 
 {% if network_substring == "main" %}
   {% assign tzstats_subdomain = "" %}

--- a/snapshot.md
+++ b/snapshot.md
@@ -150,14 +150,14 @@ Issue the following commands:
 
 ```bash
 wget {{ domain_name }}/{{ site.data.rolling_snapshot.filename }}
-tezos-node snapshot import {{ site.data.rolling_snapshot.filename }} --block ${BLOCK_HASH}
+tezos-node snapshot import {{ site.data.rolling_snapshot.filename }} --block {{ site.data.rolling_snapshot.block_hash }}
 ```
 
 Or simply use the permalink:
 
 ```bash
 wget {{ domain_name }}/rolling -O tezos-{{ site.data.tezos_metadata.network }}.rolling
-tezos-node snapshot import tezos-{{ site.data.tezos_metadata.network }}.rolling
+tezos-node snapshot import tezos-{{ site.data.tezos_metadata.network }}.rolling --block {{ site.data.rolling_snapshot.block_hash }}
 ```
 
 ### More details

--- a/snapshot.md
+++ b/snapshot.md
@@ -34,13 +34,19 @@ page_nav:
   {% assign tzstats_subdomain = network_substring | append: "." %}
   {% assign tzkt_subdomain = site.data.tezos_metadata.network | append: "." %}
 {% endif %}
+
+{% assign min = 100 %}
+{% assign max = 999 %}
+{% assign diff = max | minus: min %}
+{% assign randomNumber = "now" | date: "%N" | modulo: diff | plus: min %}
+
 # Tezos snapshots for {{ site.data.tezos_metadata.network }}
 
 Octez version used for snapshotting: `{{ site.data.rolling_snapshot.tezos_version }}`
 
 ## Rolling snapshot
 
-[Download Rolling Snapshot]({{ domain_name }}/{{ site.data.rolling_snapshot.filename }})
+[Download Rolling Snapshot]({{ domain_name }}/{{ site.data.rolling_snapshot.filename }}?{{ randomNumber }})
 
 Block height: `{{ site.data.rolling_snapshot.block_height }}`
 
@@ -58,11 +64,11 @@ Checksum (SHA256):
 {{ site.data.rolling_snapshot.sha256 }}
 ```
 
-[Artifact Metadata]({{ domain_name }}/rolling-snapshot-metadata)
+[Artifact Metadata]({{ domain_name }}/rolling-snapshot-metadata?{{ randomNumber }})
 
 ## Archive tarball
 
-[Download Archive Tarball]({{ domain_name }}/{{ site.data.archive_tarball.filename }})
+[Download Archive Tarball]({{ domain_name }}/{{ site.data.archive_tarball.filename }}?{{ randomNumber }})
 
 Block height: `{{ site.data.archive_tarball.block_height }}`
 
@@ -80,11 +86,11 @@ Checksum (SHA256):
 {{ site.data.archive_tarball.sha256 }}
 ```
 
-[Artifact Metadata]({{ domain_name }}/archive-tarball-metadata)
+[Artifact Metadata]({{ domain_name }}/archive-tarball-metadata?{{ randomNumber }})
 
 ## Rolling tarball
 
-[Download Rolling Tarball]({{ domain_name }}/{{ site.data.rolling_tarball.filename }})
+[Download Rolling Tarball]({{ domain_name }}/{{ site.data.rolling_tarball.filename }}?{{ randomNumber }})
 
 Block height: `{{ site.data.rolling_tarball.block_height }}`
 
@@ -102,7 +108,7 @@ Checksum (SHA256):
 {{ site.data.rolling_tarball.sha256 }}
 ```
 
-[Artifact Metadata]({{ domain_name }}/rolling-tarball-metadata)
+[Artifact Metadata]({{ domain_name }}/rolling-tarball-metadata?{{ randomNumber }})
 
 ## How to use
 

--- a/snapshot.md
+++ b/snapshot.md
@@ -3,47 +3,159 @@
 layout: snapshot
 keywords:
 comments: false
-
 # Hero section
-title: Mainnet snapshots
-description: 
-
+title: Tezos snapshots for ${NETWORK}
+description:
 # Author box
 author:
-    title: Oxhead Alpha
-    title_url: 'https://oxheadalpha.com'
-    external_url: true
-    description: Oxhead Alpha is a tezos core development company
-
+  title: Brought to you by Oxhead Alpha
+  title_url: "https://medium.com/the-aleph"
+  external_url: true
+  description: A Tezos core development company, providing common goods for the Tezos ecosystem. <a href="https://medium.com/the-aleph" target="_blank">Learn more</a>.
 # Micro navigation
 micro_nav: true
-
 # Page navigation
 page_nav:
-    home:
-        content: Previous page
-        url: 'https://xtz-shots.io/index.html'
+  home:
+    content: Previous page
+    url: https://xtz-shots.io/index.html
 ---
 
-## Tezos snapshot for ${TEZOS_NETWORK}
+{% assign network_substring = site.data.tezos_metadata.network | remove: "net" %}
+{% capture domain_name %}https://{{ site.data.tezos_metadata.network }}.{{ site.domain_name }}{% endcapture %}
 
-Block height: $BLOCK_HEIGHT
+{% if network_substring == "main" %}
+  {% assign tzstats_subdomain = "" %}
+  {% assign tzkt_subdomain = "" %}
+{% elsif network_substring == "hangzhou" %}
+  {% assign tzstats_subdomain = network_substring | append: "." %}
+  {% assign tzkt_subdomain = "hangzhou2net" | append: "." %}
+{% else %}
+  {% assign tzstats_subdomain = network_substring | append: "." %}
+  {% assign tzkt_subdomain = site.data.tezos_metadata.network | append: "." %}
+{% endif %}
+# Tezos snapshots for {{ site.data.tezos_metadata.network }}
 
-Block hash: \`${BLOCK_HASH}\` - [Verify on TzStats](https://tzstats.com/${BLOCK_HASH}) - [Verify on TzKT](https://tzkt.io/${BLOCK_HASH})
-
-Block timestamp: $BLOCK_TIMESTAMP
+Octez version used for snapshotting: `{{ site.data.rolling_snapshot.tezos_version }}`
 
 ## Rolling snapshot
 
-[Rolling Snapshot](${snapshot_name}.rolling)
+[Download Rolling Snapshot]({{ domain_name }}/{{ site.data.rolling_snapshot.filename }})
 
-## Full snapshot
+Block height: `{{ site.data.rolling_snapshot.block_height }}`
 
-[Full Snapshot](${snapshot_name}.full)
+Block hash: `{{ site.data.rolling_snapshot.block_hash }}`
 
-HOW TO USE
+[Verify on TzStats](https://{{ tzstats_subdomain }}tzstats.com/{{ site.data.rolling_snapshot.block_hash }}){:target="\_blank"} - [Verify on TzKT](https://{{ tzkt_subdomain }}tzkt.io/{{ site.data.rolling_snapshot.block_hash }}){:target="\_blank"}
+
+Block timestamp: `{{ site.data.rolling_snapshot.block_timestamp }}`
+
+Size in bytes: `{{ site.data.rolling_snapshot.filesize_bytes }}`
+
+Checksum (SHA256):
 
 ```
-wget https://delphinet.xtz-shots.io/tezos-delphinet-83316.rolling
-tezos-node snapshot import tezos-delphinet-83316.rolling --block BMDKHftB5biRp9ZdkcMaoGby5UhT38eR8ntB1SWQ54fDNqKgr1n
+{{ site.data.rolling_snapshot.sha256 }}
 ```
+
+[Artifact Metadata]({{ domain_name }}/rolling-snapshot-metadata)
+
+## Archive tarball
+
+[Download Archive Tarball]({{ domain_name }}/{{ site.data.archive_tarball.filename }})
+
+Block height: `{{ site.data.archive_tarball.block_height }}`
+
+Block hash: `{{ site.data.archive_tarball.block_hash }}`
+
+[Verify on TzStats](https://{{ tzstats_subdomain }}tzstats.com/{{ site.data.archive_tarball.block_hash }}){:target="\_blank"} - [Verify on TzKT](https://{{ tzkt_subdomain }}tzkt.io/{{ site.data.archive_tarball.block_hash }}){:target="\_blank"}
+
+Block timestamp: `{{ site.data.archive_tarball.block_timestamp }}`
+
+Size in bytes: `{{ site.data.archive_tarball.filesize_bytes }}`
+
+Checksum (SHA256):
+
+```
+{{ site.data.archive_tarball.sha256 }}
+```
+
+[Artifact Metadata]({{ domain_name }}/archive-tarball-metadata)
+
+## Rolling tarball
+
+[Download Rolling Tarball]({{ domain_name }}/{{ site.data.rolling_tarball.filename }})
+
+Block height: `{{ site.data.rolling_tarball.block_height }}`
+
+Block hash: `{{ site.data.rolling_tarball.block_hash }}`
+
+[Verify on TzStats](https://{{ tzstats_subdomain }}tzstats.com/{{ site.data.rolling_tarball.block_hash }}){:target="\_blank"} - [Verify on TzKT](https://{{ tzkt_subdomain }}tzkt.io/{{ site.data.rolling_tarball.block_hash }}){:target="\_blank"}
+
+Block timestamp: `{{ site.data.rolling_tarball.block_timestamp }}`
+
+Size in bytes: `{{ site.data.rolling_tarball.filesize_bytes }}`
+
+Checksum (SHA256):
+
+```
+{{ site.data.rolling_tarball.sha256 }}
+```
+
+[Artifact Metadata]({{ domain_name }}/rolling-tarball-metadata)
+
+## How to use
+
+### Archive Tarball
+
+Issue the following commands:
+
+```bash
+curl -L "{{ domain_name }}/{{ site.data.archive_tarball.filename }}" \
+| lz4 -d | tar -x -C "/var/tezos"
+```
+
+Or simply use the permalink:
+
+```bash
+curl -L "{{ domain_name }}/archive-tarball" \
+| lz4 -d | tar -x -C "/var/tezos"
+```
+
+### Rolling Tarball
+
+Issue the following commands:
+
+```bash
+curl -L "{{ domain_name }}/{{ site.data.rolling_tarball.filename }}" \
+| lz4 -d | tar -x -C "/var/tezos"
+```
+
+Or simply use the permalink:
+
+```bash
+curl -L "{{ domain_name }}/rolling-tarball" \
+| lz4 -d | tar -x -C "/var/tezos"
+```
+
+### Rolling Snapshot
+
+Issue the following commands:
+
+```bash
+wget {{ domain_name }}/{{ site.data.rolling_snapshot.filename }}
+tezos-node snapshot import {{ site.data.rolling_snapshot.filename }} --block ${BLOCK_HASH}
+```
+
+Or simply use the permalink:
+
+```bash
+wget {{ domain_name }}/rolling -O tezos-{{ site.data.tezos_metadata.network }}.rolling
+tezos-node snapshot import tezos-{{ site.data.tezos_metadata.network }}.rolling
+```
+
+### More details
+
+[About xtz-shots.io]({{ site.url }}/getting-started/).
+
+[Tezos documentation](https://tezos.gitlab.io/user/snapshots.html){:target="\_blank"}.


### PR DESCRIPTION
Writes the templating in this repo instead of needing to write it in the snapshot engine's zip and upload job. The goal is to remove the front end components from the snapshot engine. The engine should be able to pull any jekyll theme and not be tied to our theme.